### PR TITLE
Use printf(1) in a POSIX-compliant way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	ca65 80columns.s
 	ca65 -o charset.o charset.s
 	ld65 -C 80columns.cfg 80columns.o charset.o -o 80columns.bin
-	printf "\x00\xc8" > 80columns.prg
+	printf "\0\310" > 80columns.prg
 	cat 80columns.bin >> 80columns.prg
 	exomizer sfx 51200 -q -n -o 80columns-compressed.prg 80columns.prg
 


### PR DESCRIPTION
I couldn't figure out why the Makefile didn't work!  It turns out that on Debian Stretch, the printf(1) implementation in /bin/sh omits "\xXX" specifiers, because the POSIX standard permits it.

POSIX printf(1) doesn't support the \xXX specifier to print characters by their hexadecimal values.  By contrast, printing octal values is portable.

Reference: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html

Signed-off-by: Jeff Epler <jepler@unpythonic.net>