### PR TITLE
Makefile: build loadable character sets, d64 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,29 @@
 .PHONY: all
 all: 80columns-compressed.prg 80c2-compressed.prg 80c3-compressed.prg 80c4-compressed.prg
+all: charset.prg charset2.prg charset3.prg charset4.prg
+all: 80columns.d64
+
+80columns.d64: 80columns-compressed.prg charset.prg charset2.prg charset3.prg charset4.prg
+	rm -f $@
+	c1541 -format 80columns,80 d64 80columns.d64.tmp
+	for i in $^; do \
+		c1541 -attach 80columns.d64.tmp -write $$i $${i%[-.]*}; \
+	done
+	mv -f 80columns.d64.tmp 80columns.d64
 
 .INTERMEDIATE: charset.bin
+charset.prg: charset.bin
+	(printf '\0\320'; cat $<) > $@.tmp
+	exomizer sfx 51200 -q -n -o $@ $@.tmp
+	rm -f $@.tmp
+
 charset.bin: charset.o charset.cfg
 	ld65 -C charset.cfg $< -o $@
+
+charset%.prg: charset%.bin
+	(printf '\0\320'; cat $<) > $@.tmp
+	exomizer sfx 51200 -q -n -o $@ $@.tmp
+	rm -f $@.tmp
 
 charset%.bin: charset%.o charset.cfg
 	ld65 -C charset.cfg $< -o $@
@@ -37,4 +57,4 @@ update-font-images: charset.bin charset2.bin charset3.bin charset4.bin mkfontimg
 
 .PHONY: clean
 clean:
-	rm -f *.prg *.bin *.o
+	rm -f *.prg *.bin *.o 80columns.d64

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Building requires a UNIX environment and [cc65](https://github.com/cc65/cc65) an
 
 The source contains four character sets (`charset.s`, `charset2.s` etc.) from different 80 column software solutions, which can be selected by changing the reference to the filename in the `Makefile`.
 
+You can also `LOAD`/`RUN` a new exomizer-compressed character set into memory, though this destroys the currently-loaded BASIC program.
+
 ### charset.s: 80COLUMNS
 ![](img/g1.png)![](img/t1.png)### charset2.s: COLOR 80 by Richvale Telecommunications![](img/g2.png)![](img/t2.png)### charset3.s: Highspeed80 by CKtwo![](img/g3.png)![](img/t3.png)### charset4.s: SCREEN-80 by Compute’s Gazette![](img/g4.png)![](img/t4.png)
 


### PR DESCRIPTION
.. technical details seem to prevent them loading directly to $D000, but they're nice and small when exomizer-compressed so it's a win-win to do it this way, except for blowing away the existing BASIC program.  As far as I could tell, SYS51200 is "safe" to do again to load the new character set, but perhaps there's a better address to jump to when exomizer is done compressing, but this seems to be the only *fixed* address..