### PR TITLE
Makefile: make c1541 optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ export PATH:= $(abspath bin):$(PATH)
 .PHONY: all
 all: 80columns-compressed.prg 80c2-compressed.prg 80c3-compressed.prg 80c4-compressed.prg
 all: charset.prg charset2.prg charset3.prg charset4.prg
+
+ifneq ($(shell which c1541 2>/dev/null),)
 all: 80columns.d64
+endif
 
 80columns.d64: 80columns-compressed.prg charset.prg charset2.prg charset3.prg charset4.prg
 	rm -f $@

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Building requires a UNIX environment and [cc65](https://github.com/cc65/cc65) an
 Running `make toolchain` will download and build cc65 and exomizer, assuming that you have a basic C development environment available.
 (If your system has packages of cc65 or exomizer, it is probably better to use those, e.g., with `brew install cc65 exomizer` on MacOS)
 Running `make` will produce `80columns-compressed.prg`, which is about 2.2 KB in size and can be started using `LOAD`/`RUN`.
+If the `c1541` program is available, it will also create a disk image `80columns.d64` containing the main program and the alternative fonts.
 
 ## Features
 


### PR DESCRIPTION
.. but note that having it installed will produce this additional target

When I added support for making .d64 images with c1541 back in #6, I wasn't thinking about how c1541 was a new requirement.  One option would be to add it to the stuff built by `make toolchain`, and another would be to automatically skip it if the c1541 program is not on the PATH.  This PR implements that option.  Let me know if you'd prefer I investigate making `make toolchain` build vice's c1541 as well.