### PR TITLE
Build the project with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,13 @@ jobs:
         path: |
           *.d64
           *.prg
+
+    - name: Create release                                                      
+      if: startsWith(github.ref, 'refs/tags/')                                  
+      uses: softprops/action-gh-release@v1                                      
+      with:                                                                     
+        files: |
+          *.d64
+          *.prg
+        fail_on_unmatched_files: true
+        body: "Automatically created release"                                                                            

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
+  check_suite:
+    types: [rerequested]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: install deps
+      run: sudo apt install vice
+
+    - name: build toolchain
+      run: make toolchain -j$(nproc)
+
+    - name: build 80columns
+      run: make -j$(nproc)
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: |
+          *.d64
+          *.prg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         submodules: true
 
     - name: install deps
-      run: sudo apt install vice
+      run: sudo apt install vice cc65
 
     - name: build toolchain
-      run: make toolchain -j$(nproc)
+      run: make toolchain-exomizer -j$(nproc)
 
     - name: build 80columns
       run: make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,5 @@ jobs:
       with:                                                                     
         files: |
           *.d64
-          *.prg
         fail_on_unmatched_files: true
         body: "Automatically created release"                                                                            


### PR DESCRIPTION
This produces a zip file with all the .prg files as well as the d64 image. Until it's cleaned by github in a few weeks, a completed run can be seen at https://github.com/jepler/80columns/actions/runs/1264087972

![image](https://user-images.githubusercontent.com/1517291/134441374-326c8859-e7c8-4232-b78a-375ccc6f3961.png)
