### PR TITLE
reorder 64 so that the non-reu version is first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifneq ($(shell which c1541 2>/dev/null),)
 all: 80columns.d64
 endif
 
-80columns.d64: 80colreu-compressed.prg 80columns-compressed.prg charset.prg charset2.prg charset3.prg charset4.prg
+80columns.d64: 80columns-compressed.prg 80colreu-compressed.prg charset.prg charset2.prg charset3.prg charset4.prg
 	rm -f $@
 	c1541 -format 80columns,80 d64 80columns.d64.tmp
 	for i in $^; do \


### PR DESCRIPTION
Ah, why do we always notice things a moment too late.

I realized that the REU version of the 80columns program was placed first on the d64 image, so most people who `LOAD"*",8,1` will get broken scrolling. This fixes the problem, by placing the traditional non-REU version first.